### PR TITLE
Use ifdef HAVE_MALLOC_H to fix compile under MAC OS X

### DIFF
--- a/src/id3misc.c
+++ b/src/id3misc.c
@@ -21,7 +21,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-//#include <malloc.h>
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#endif
 #include <stdarg.h>
 #include <errno.h>
 #include <ctype.h>

--- a/src/id3ren.c
+++ b/src/id3ren.c
@@ -20,7 +20,9 @@
  */
 
 #include <stdio.h>
-//#include <malloc.h>
+#ifdef HAVE_MALLOC_H
+#include <malloc.h>
+#endif
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
Signed-off-by: Jari Aalto jari.aalto@cante.net
